### PR TITLE
Make it say GBTOS instead of GBTS

### DIFF
--- a/02-bootsector-print/load_msg_boot_sector.asm
+++ b/02-bootsector-print/load_msg_boot_sector.asm
@@ -12,6 +12,10 @@ mov al, 'T'
 
 int 0x10
 
+mov al, 'O'
+
+int 0x10
+
 int 0x10 ; 'O' is still on al, remember?
 
 mov al, 'S'


### PR DESCRIPTION
I found that it used to say GBTS instead of GBTOS so this fixes it.